### PR TITLE
Cleaned up some "form"

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -32,5 +32,5 @@ package() {
   cd "$srcdir/$pkgname"
   python setup.py install --root="$pkgdir/" --optimize=1
   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
-  install -Dm544 darkhttpd.service "$pkgdir/etc/systemd/system/darkhttpd.service"
+  install -Dm544 aur_repo.service "$pkgdir/etc/systemd/system/aur_repo.service"
 }

--- a/aur_repo.install
+++ b/aur_repo.install
@@ -8,5 +8,4 @@ pre_install() {
         mkdir /var/log/aur_repo
         chown build /var/log/aur_repo
         touch /etc/aur_repo/pkglist
-        systemctl enable darkhttpd
 }

--- a/aur_repo.service
+++ b/aur_repo.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Darkhttpd Webserver
+Description=aur_repo server (darkhttpd)
 
 [Service]
 Type=simple


### PR DESCRIPTION
The systemd unit was named Darkhttpd... Which is technically misleading since the point isn't to enable/start darkhttpd, but something that serves a repo readable by pacman. I've renamed it to aur_repo and changed the description to be more accurate.

That takes me to the other commit: I, at least, am not OK with _anything_ enabling itself automatically on install, and I've never seen any package in Arch do so. In fact, it's probably not very helpful in some cases, since I particularly already have an nginx running in the machine aur_repo is useful, so it would just fail to start anyway.
